### PR TITLE
Fix #211: JSON Logging Foundation

### DIFF
--- a/signer-cloud-server/docker/deploy/conf/logback/scs-logback.xml
+++ b/signer-cloud-server/docker/deploy/conf/logback/scs-logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <springProperty scope="context" name="appname" source="spring.application.name"/>
+    <springProperty scope="context" name="appname" source="spring.application.name" defaultValue="unknown"/>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <includeMdc>true</includeMdc>

--- a/signer-cloud-server/docker/deploy/conf/logback/scs-logback.xml
+++ b/signer-cloud-server/docker/deploy/conf/logback/scs-logback.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <springProperty scope="context" name="appname" source="spring.application.name"/>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <includeMdc>true</includeMdc>
-            <customFields>{"appname":"signer-cloud-server"}</customFields>
+            <omitEmptyFields>true</omitEmptyFields>
+            <customFields>{"appname":"${appname}"}</customFields>
         </encoder>
     </appender>
 


### PR DESCRIPTION
## Summary

Fixes #211 — JSON Logging Foundation for `signer-cloud`.

### Changes

- **L3**: Replace hardcoded `appname` in `scs-logback.xml` with `<springProperty>` sourced from `spring.application.name`
- **+**: Add `<omitEmptyFields>true</omitEmptyFields>` to suppress empty MDC fields from JSON output

### Affected files

- `signer-cloud-server/docker/deploy/conf/logback/scs-logback.xml`

### Notes

- `spring.application.name=signer-cloud-server` already set ✅
- `logstash-logback-encoder` version `8.1` is already the latest — no version bump needed ✅

### References

- Issue: #211
- Epic: wultra/tasklist#863 (JSON Logging Foundation)
- Logging Guideline: https://github.com/wultra/development-internal/wiki/Logging-Guideline

---

### Follow-up: defaultValue for springProperty

Added `defaultValue="unknown"` to `<springProperty>` in all logback configs.

`<springProperty>` is fully supported when the config is loaded via Spring Boot's Logback configurator (standard production path via `logging.config`). The `defaultValue` is a safety net for the edge case where the file is loaded as a plain Logback config outside of Spring Boot — in that scenario `spring.application.name` cannot be resolved and the fallback prevents `appname_IS_UNDEFINED` appearing in log output.