### PR TITLE
Fix #221: Register Lombok annotation processor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,18 @@
                 <artifactId>cyclonedx-maven-plugin</artifactId>
                 <version>${cyclonedx-maven-plugin.version}</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
## Description

Registers Lombok as an explicit Maven annotation processor in the Maven compiler plugin configuration.

## Motivation and Context

JDK 23+ disables implicit annotation processor discovery by default, so Lombok must be configured explicitly for Java 25 compatibility.

Closes #221