### PR TITLE
feat #220: adopt structured logging with StructuredArguments.kv

### DIFF
--- a/signer-cloud-server/src/main/java/com/wultra/signercloud/server/callback/CallbackEventResponseHandler.java
+++ b/signer-cloud-server/src/main/java/com/wultra/signercloud/server/callback/CallbackEventResponseHandler.java
@@ -28,6 +28,8 @@ import org.springframework.util.Assert;
 import java.time.Duration;
 import java.time.LocalDateTime;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Handlers of a Callback Event response.
  *
@@ -57,7 +59,7 @@ class CallbackEventResponseHandler {
                 .orElseThrow(() -> new IllegalStateException("Callback Event was not found in database during its success handling: callbackEventId=" + callbackEventData.id()));
 
         final CallbackConfigurationProperties.CallbackConfiguration callbackConfiguration = configuration.callbackConfigurationFor(callbackEvent.getCallbackType());
-        logger.info("Callback succeeded, URL={}, callbackEventId={}", callbackConfiguration.url(), callbackEvent.getId());
+        logger.info("Callback succeeded", kv("url", callbackConfiguration.url()), kv("callbackEventId", callbackEvent.getId()));
 
         final Duration retentionPeriod = callbackConfiguration.retentionPeriod();
 
@@ -84,7 +86,7 @@ class CallbackEventResponseHandler {
                 .orElseThrow(() -> new IllegalStateException("Callback Event was not found in database during its failure handling: callbackEventId=" + callbackEventData.id()));
 
         final CallbackConfigurationProperties.CallbackConfiguration callbackConfiguration = configuration.callbackConfigurationFor(callbackEvent.getCallbackType());
-        logger.info("Callback failed, URL={}, callbackEventId={}, error={}", callbackConfiguration.url(), callbackEvent.getId(), error.getMessage());
+        logger.info("Callback failed", kv("url", callbackConfiguration.url()), kv("callbackEventId", callbackEvent.getId()), kv("errorMessage", error.getMessage()));
 
         final CallbackEvent.CallbackEventBuilder builder = callbackEvent.toBuilder()
                 .attempts(callbackEvent.getAttempts() + 1)
@@ -99,7 +101,7 @@ class CallbackEventResponseHandler {
             builder.timestampNextCall(LocalDateTime.now().plus(backoffPeriod))
                     .status(CallbackEventStatus.PENDING);
         } else {
-            logger.debug("Maximum number of attempts reached for callbackEventId={}", callbackEvent.getId());
+            logger.debug("Maximum number of attempts reached", kv("callbackEventId", callbackEvent.getId()));
             final Duration retentionPeriod = callbackConfiguration.retentionPeriod();
             builder.timestampDeleteAfter(LocalDateTime.now().plus(retentionPeriod))
                     .timestampNextCall(null)

--- a/signer-cloud-server/src/main/java/com/wultra/signercloud/server/callback/CallbackJob.java
+++ b/signer-cloud-server/src/main/java/com/wultra/signercloud/server/callback/CallbackJob.java
@@ -24,6 +24,8 @@ import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * A scheduled job that performs cleanup operations on signers.
  *
@@ -42,27 +44,27 @@ class CallbackJob {
     @SchedulerLock(name = "dispatchPendingCallbackEvents")
     public void dispatchPendingCallbackEvents() {
         final int limit = configurationProperties.getDispatchPendingCallbackEvents().job().limit();
-        logger.info("action: dispatchPendingCallbackEvents, state: initiated, limit: {}", limit);
+        logger.info("Dispatch pending callback events initiated", kv("action", "dispatchPendingCallbackEvents"), kv("state", "initiated"), kv("limit", limit));
         LockAssert.assertLocked();
         final var result = callbackService.dispatchPendingCallbackEvents(limit);
-        logger.info("action: dispatchPendingCallbackEvents, state: succeeded, count: {}", result);
+        logger.info("Dispatch pending callback events succeeded", kv("action", "dispatchPendingCallbackEvents"), kv("state", "succeeded"), kv("count", result));
     }
 
     @Scheduled(cron = "${signer-cloud.server.callback.cleanup-callback-events.job.cron}", zone = "UTC")
     @SchedulerLock(name = "cleanupCallbackEvents")
     public void cleanupCallbackEvents() {
-        logger.info("action: cleanupCallbackEvents, state: initiated");
+        logger.info("Cleanup callback events initiated", kv("action", "cleanupCallbackEvents"), kv("state", "initiated"));
         LockAssert.assertLocked();
         final var result = callbackService.deleteCallbackEventsAfterRetentionPeriod();
-        logger.info("action: cleanupCallbackEvents, state: succeeded, count: {}", result);
+        logger.info("Cleanup callback events succeeded", kv("action", "cleanupCallbackEvents"), kv("state", "succeeded"), kv("count", result));
     }
 
     @Scheduled(cron = "${signer-cloud.server.callback.rerun-stale-callback-events.job.cron}", zone = "UTC")
     @SchedulerLock(name = "rerunStaleCallbackEvents")
     public void rerunStaleCallbackEvents() {
-        logger.info("action: rerunStaleCallbackEvents, state: initiated");
+        logger.info("Rerun stale callback events initiated", kv("action", "rerunStaleCallbackEvents"), kv("state", "initiated"));
         LockAssert.assertLocked();
         final var result = callbackService.resetStaleCallbackEvents();
-        logger.info("action: rerunStaleCallbackEvents, state: succeeded, count: {}", result);
+        logger.info("Rerun stale callback events succeeded", kv("action", "rerunStaleCallbackEvents"), kv("state", "succeeded"), kv("count", result));
     }
 }

--- a/signer-cloud-server/src/main/java/com/wultra/signercloud/server/callback/CallbackNotificationServiceInternal.java
+++ b/signer-cloud-server/src/main/java/com/wultra/signercloud/server/callback/CallbackNotificationServiceInternal.java
@@ -26,6 +26,8 @@ import org.springframework.stereotype.Service;
 
 import java.util.concurrent.RejectedExecutionException;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Implementation of {@link CallbackNotificationService}.
  *
@@ -44,7 +46,7 @@ class CallbackNotificationServiceInternal implements CallbackNotificationService
     @Override
     public void notify(final CallbackType callbackType, final String callbackData) {
         if (callbackService.failureThresholdReached(callbackType)) {
-            logger.warn("Callback has reached failure threshold, associated events are not dispatched: callbackType={}", callbackType);
+            logger.warn("Callback has reached failure threshold, associated events are not dispatched", kv("callbackType", callbackType));
             callbackService.createAndSaveFailedEvent(callbackType, callbackData);
             return;
         }
@@ -67,8 +69,8 @@ class CallbackNotificationServiceInternal implements CallbackNotificationService
         try {
             callbackQueueService.submitToExecutor(callbackEventData);
         } catch (RejectedExecutionException e) {
-            logger.info("CallbackEvent was rejected by the executor, saving to database: callbackEventId={}, {}", callbackEventData.id(), e.getMessage());
-            logger.debug("CallbackEvent was rejected by the executor, saving to database: callbackEventId={}", callbackEventData.id(), e);
+            logger.info("CallbackEvent was rejected by the executor, saving to database", kv("callbackEventId", callbackEventData.id()), kv("errorMessage", e.getMessage()));
+            logger.debug("CallbackEvent was rejected by the executor, saving to database", kv("callbackEventId", callbackEventData.id()), e);
             callbackQueueService.enqueueToDatabase(callbackEventData);
         }
     }

--- a/signer-cloud-server/src/main/java/com/wultra/signercloud/server/callback/CallbackRestClientConfiguration.java
+++ b/signer-cloud-server/src/main/java/com/wultra/signercloud/server/callback/CallbackRestClientConfiguration.java
@@ -39,6 +39,8 @@ import java.util.Base64;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Configuration creating {@link CallbackRestClient}.
  *
@@ -59,7 +61,7 @@ class CallbackRestClientConfiguration {
     }
 
     private CallbackRestClient createCallbackRestClient(final CallbackType callbackType, final CallbackConfigurationProperties configuration) throws RestClientException {
-        logger.info("Initiating RestClient for callbackType={}", callbackType);
+        logger.info("Initiating RestClient", kv("callbackType", callbackType));
         return CallbackRestClient.builder()
                 .restClient(initializeRestClient(callbackType, configuration))
                 .timestampCreated(LocalDateTime.now())

--- a/signer-cloud-server/src/main/java/com/wultra/signercloud/server/callback/CallbackService.java
+++ b/signer-cloud-server/src/main/java/com/wultra/signercloud/server/callback/CallbackService.java
@@ -39,6 +39,8 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Consumer;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Callback service.
  *
@@ -136,7 +138,7 @@ class CallbackService {
     @Transactional
     public int resetStaleCallbackEvents() {
         final int numberOfAffectedEvents = callbackEventRepository.updateStaleEventsToPendingState(LocalDateTime.now());
-        logger.info("Number of stale Callback Events moved to PENDING state: {}", numberOfAffectedEvents);
+        logger.info("Stale Callback Events moved to PENDING state", kv("affectedEvents", numberOfAffectedEvents));
         return numberOfAffectedEvents;
     }
 
@@ -157,7 +159,7 @@ class CallbackService {
         final CallbackRestClient callbackRestClient = fetchCallbackRestClient(callbackType);
 
         if (failureThresholdReached(callbackRestClient)) {
-            logger.warn("Callback has reached failure threshold, associated events are not dispatched: callbackType={}", callbackType);
+            logger.warn("Callback has reached failure threshold, associated events are not dispatched", kv("callbackType", callbackType));
             failWithoutDispatching(callbackEvent);
             return;
         }
@@ -200,7 +202,7 @@ class CallbackService {
         final LocalDateTime timestampLastFailure = callbackRestClient.timestampLastFailure().get();
 
         if (failureCount >= failureThreshold && LocalDateTime.now().minus(resetTimeout).isAfter(timestampLastFailure)) {
-            logger.debug("Callback reached failure threshold, but before specified reset timeout period, callbackType={}", callbackRestClient.callbackType());
+            logger.debug("Callback reached failure threshold, but before specified reset timeout period", kv("callbackType", callbackRestClient.callbackType()));
             return false;
         }
 
@@ -248,7 +250,7 @@ class CallbackService {
      */
     private void postCallback(final CallbackEventData callbackEventData) {
         if (callbackEventData.status() != CallbackEventStatus.PROCESSING) {
-            logger.warn("Callback Event to post is not in PROCESSING state: callbackEventId={}", callbackEventData.id());
+            logger.warn("Callback Event to post is not in PROCESSING state", kv("callbackEventId", callbackEventData.id()));
             return;
         }
 
@@ -270,7 +272,7 @@ class CallbackService {
                     onSuccess,
                     onError);
 
-            logger.debug("CallbackEvent {} was dispatched.", callbackEventData.id());
+            logger.debug("CallbackEvent was dispatched", kv("callbackEventId", callbackEventData.id()));
         } catch (final RestClientException e) {
             callbackEventResponseHandler.handleFailure(callbackEventData, e);
         }

--- a/signer-cloud-server/src/main/java/com/wultra/signercloud/server/configuration/OnlineTSPSourceConfig.java
+++ b/signer-cloud-server/src/main/java/com/wultra/signercloud/server/configuration/OnlineTSPSourceConfig.java
@@ -25,6 +25,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Configuration for TSA source.
  *
@@ -41,7 +43,7 @@ class OnlineTSPSourceConfig {
     @ConditionalOnProperty("signer-cloud.server.pades.tsa-url")
     public OnlineTSPSource tspSource() {
         final var tsaUrl = pAdESConfigurationProperties.getTsaUrl();
-        logger.info("Setting TSA URL: {}", tsaUrl);
+        logger.info("Setting TSA URL", kv("tsaUrl", tsaUrl));
 
         final var onlineTspSource = new OnlineTSPSource(tsaUrl);
         onlineTspSource.setDataLoader(new TimestampDataLoader());

--- a/signer-cloud-server/src/main/java/com/wultra/signercloud/server/document/DocumentCleanupJob.java
+++ b/signer-cloud-server/src/main/java/com/wultra/signercloud/server/document/DocumentCleanupJob.java
@@ -24,6 +24,8 @@ import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * A scheduled job that performs cleanup operations on documents.
  *
@@ -39,9 +41,9 @@ class DocumentCleanupJob {
     @Scheduled(cron = "${signer-cloud.server.document.cleanup.cron}", zone = "UTC")
     @SchedulerLock(name = "cleanupDocuments")
     public void cleanupDocuments() {
-        logger.info("action: cleanupDocuments, state: initiated");
+        logger.info("Cleanup documents initiated", kv("action", "cleanupDocuments"), kv("state", "initiated"));
         LockAssert.assertLocked();
         final var result = documentService.cleanupDocuments();
-        logger.info("action: cleanupDocuments, state: succeeded, {}", result);
+        logger.info("Cleanup documents succeeded", kv("action", "cleanupDocuments"), kv("state", "succeeded"), kv("count", result));
     }
 }

--- a/signer-cloud-server/src/main/java/com/wultra/signercloud/server/document/DocumentController.java
+++ b/signer-cloud-server/src/main/java/com/wultra/signercloud/server/document/DocumentController.java
@@ -31,6 +31,8 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Controller for {@link Document} operations.
  *
@@ -98,17 +100,17 @@ public class DocumentController {
             )
             @RequestPart(value = "visualSignature", required = false) final DocumentVisualSignature visualSignature
     ) {
-        logger.info("action: uploadDocument, state: initiated, externalSignerId: {}, documentExternalId: {}", externalSignerId, externalId);
+        logger.info("Upload document initiated", kv("action", "uploadDocument"), kv("state", "initiated"), kv("externalSignerId", externalSignerId), kv("documentExternalId", externalId));
         final var result = Try.execute(
                 () -> documentService.uploadDocument(externalSignerId, externalId, documentName, file, visualSignature)
         );
 
         if (result.isSuccess()) {
             final var response = result.getResponse();
-            logger.info("action: uploadDocument, state: succeeded, documentId: {}, hash: {}", response.documentId(), response.hash());
+            logger.info("Upload document succeeded", kv("action", "uploadDocument"), kv("state", "succeeded"), kv("documentId", response.documentId()), kv("hash", response.hash()));
             return response;
         } else {
-            logger.error("action: uploadDocument, state: failed, errorMessage: {}", result.getError().getMessage());
+            logger.error("Upload document failed", kv("action", "uploadDocument"), kv("state", "failed"), kv("errorMessage", result.getError().getMessage()));
             throw result.getError();
         }
     }
@@ -148,16 +150,16 @@ public class DocumentController {
             )
             @PathVariable final String documentId,
             @Valid @RequestBody final SignDocumentRequest requestBody) {
-        logger.info("action: signDocument, state: initiated, documentId: {}", documentId);
+        logger.info("Sign document initiated", kv("action", "signDocument"), kv("state", "initiated"), kv("documentId", documentId));
         final var result = Try.execute(
                 () -> documentService.signDocument(documentId, requestBody)
         );
 
         if (result.isSuccess()) {
-            logger.info("action: signDocument, state: succeeded");
+            logger.info("Sign document succeeded", kv("action", "signDocument"), kv("state", "succeeded"), kv("documentId", documentId));
             return result.getResponse();
         } else {
-            logger.info("action: signDocument, state: failed, errorMessage: {}", result.getError().getMessage());
+            logger.info("Sign document failed", kv("action", "signDocument"), kv("state", "failed"), kv("documentId", documentId), kv("errorMessage", result.getError().getMessage()));
             throw result.getError();
         }
     }
@@ -200,17 +202,17 @@ public class DocumentController {
             )
             @RequestHeader(value = "Range", required = false) final String rangeHeader
     ) {
-        logger.info("action: downloadDocument, state: initiated, documentId: {}, ranges: {}", documentId, rangeHeader);
+        logger.info("Download document initiated", kv("action", "downloadDocument"), kv("state", "initiated"), kv("documentId", documentId), kv("ranges", rangeHeader));
         final var result = Try.execute(
                 () -> documentService.downloadDocument(documentId)
         );
 
         if (result.isSuccess()) {
-            logger.info("action: downloadDocument, state: succeeded");
+            logger.info("Download document succeeded", kv("action", "downloadDocument"), kv("state", "succeeded"), kv("documentId", documentId));
             return result.getResponse();
         } else {
             final var error = result.getError();
-            logger.info("action: downloadDocument, state: failed, errorMessage: {}", error.getMessage());
+            logger.info("Download document failed", kv("action", "downloadDocument"), kv("state", "failed"), kv("documentId", documentId), kv("errorMessage", error.getMessage()));
             throw error;
         }
     }
@@ -241,17 +243,17 @@ public class DocumentController {
             @PathVariable final String documentId,
             @Valid @RequestBody final RejectDocumentRequest requestBody
     ) {
-        logger.info("action: rejectDocument, state: initiated, documentId: {}", documentId);
+        logger.info("Reject document initiated", kv("action", "rejectDocument"), kv("state", "initiated"), kv("documentId", documentId));
         final var result = Try.execute(
                 () -> documentService.rejectDocument(documentId, requestBody)
         );
 
         if (result.isSuccess()) {
-            logger.info("action: rejectDocument, state: succeeded");
+            logger.info("Reject document succeeded", kv("action", "rejectDocument"), kv("state", "succeeded"), kv("documentId", documentId));
             return result.getResponse();
         } else {
             final var error = result.getError();
-            logger.info("action: rejectDocument, state: failed, errorMessage: {}", error.getMessage());
+            logger.info("Reject document failed", kv("action", "rejectDocument"), kv("state", "failed"), kv("documentId", documentId), kv("errorMessage", error.getMessage()));
             throw error;
         }
     }
@@ -275,8 +277,8 @@ public class DocumentController {
             )
             @PathVariable final String documentId
     ) {
-        logger.info("action: deleteDocument, state: initiated, documentId: {}", documentId);
+        logger.info("Delete document initiated", kv("action", "deleteDocument"), kv("state", "initiated"), kv("documentId", documentId));
         documentService.deleteDocument(documentId);
-        logger.info("action: deleteDocument, state: succeeded");
+        logger.info("Delete document succeeded", kv("action", "deleteDocument"), kv("state", "succeeded"), kv("documentId", documentId));
     }
 }

--- a/signer-cloud-server/src/main/java/com/wultra/signercloud/server/document/DocumentService.java
+++ b/signer-cloud-server/src/main/java/com/wultra/signercloud/server/document/DocumentService.java
@@ -36,6 +36,8 @@ import java.time.Instant;
 import java.util.UUID;
 import java.util.function.Consumer;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Document service.
  *
@@ -324,7 +326,7 @@ class DocumentService {
         final var documentOpt = documentRepository.findByDocumentId(documentUuid);
 
         if (documentOpt.isEmpty()) {
-            logger.warn("Document for deletion not found. Document UUID: {}", documentUuid);
+            logger.warn("Document for deletion not found", kv("documentId", documentUuid));
             return;
         }
 

--- a/signer-cloud-server/src/main/java/com/wultra/signercloud/server/ejbca/EjbcaRestClient.java
+++ b/signer-cloud-server/src/main/java/com/wultra/signercloud/server/ejbca/EjbcaRestClient.java
@@ -38,6 +38,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.util.List;
 import java.util.Map;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Rest client for EJBCA.
  *
@@ -83,7 +85,7 @@ class EjbcaRestClient {
         logger.info("Sending certificate request to EJBCA");
         logger.debug("Sending certificate request to EJBCA: {}", request);
         final ResponseEntity<CertificateResponse> response = restClient.post("/v1/certificate/pkcs10enroll", request, ParameterizedTypeReference.forType(CertificateResponse.class));
-        logger.info("Got certificate response, status code: {}", response.getStatusCode());
+        logger.info("Got certificate response from EJBCA", kv("statusCode", response.getStatusCode()));
         logger.debug("Got certificate response: {}", response.getBody());
         return response.getBody();
     }
@@ -105,7 +107,7 @@ class EjbcaRestClient {
 
         final var params = MultiValueMap.fromSingleValue(Map.of("reason", reason.name()));
 
-        logger.info("Revoking certificate, serialNumberHex: {}, issuerDN: {}, reason: {}", request.serialNumberHex(), request.issuerDN(), reason);
+        logger.info("Revoking certificate in EJBCA", kv("serialNumberHex", request.serialNumberHex()), kv("issuerDn", request.issuerDN()), kv("reason", reason));
         restClient.put(url, null, params, null, ParameterizedTypeReference.forType(Void.class));
         logger.info("Successful EJBCA certificate revoke call");
     }

--- a/signer-cloud-server/src/main/java/com/wultra/signercloud/server/ejbca/EjbcaService.java
+++ b/signer-cloud-server/src/main/java/com/wultra/signercloud/server/ejbca/EjbcaService.java
@@ -30,6 +30,8 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.List;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Service for calling EJBCA functionality.
  *
@@ -55,7 +57,7 @@ public class EjbcaService {
      */
     public CertificateResponse enrollCertificate(final CertificateRequest request) throws IOException, CertificateException, RestClientException {
         final EjbcaRestClient.CertificateResponse certificateResponse = ejbcaRestClient.callPkcs10Enroll(convert(request));
-        logger.info("Got certificate with serial number: {}", certificateResponse.serialNumber());
+        logger.info("Got certificate from EJBCA", kv("serialNumber", certificateResponse.serialNumber()));
         if (!"DER".equals(certificateResponse.responseFormat())) {
             throw new IllegalStateException("Unexpected response format: " + certificateResponse.responseFormat());
         }

--- a/signer-cloud-server/src/main/java/com/wultra/signercloud/server/powerauth/PowerAuthService.java
+++ b/signer-cloud-server/src/main/java/com/wultra/signercloud/server/powerauth/PowerAuthService.java
@@ -24,6 +24,8 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * PowerAuth service.
  *
@@ -44,10 +46,10 @@ public class PowerAuthService {
      * @throws PowerAuthClientException in case of communication or processing error
      */
     public boolean isSignatureValid(final VerifyECDSASignatureRequest request) throws PowerAuthClientException {
-        logger.info("Verifying ECDSA signature for registrationId: {}", request.getActivationId());
+        logger.info("Verifying ECDSA signature", kv("registrationId", request.getActivationId()));
         final var response = powerAuthClient.verifyECDSASignature(request);
         final var isSignatureValid = response.isSignatureValid();
-        logger.info("Signature is valid: {}", isSignatureValid);
+        logger.info("ECDSA signature verification finished", kv("registrationId", request.getActivationId()), kv("signatureValid", isSignatureValid));
         return isSignatureValid;
     }
 }

--- a/signer-cloud-server/src/main/java/com/wultra/signercloud/server/signer/CertificateRevocationService.java
+++ b/signer-cloud-server/src/main/java/com/wultra/signercloud/server/signer/CertificateRevocationService.java
@@ -29,6 +29,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigInteger;
 import java.time.Instant;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Service for revoking issued certificates in EJBCA.
  *
@@ -65,12 +67,12 @@ class CertificateRevocationService {
             ejbcaService.revokeCertificate(request);
 
             setRevokedStatus(certificateMetadata);
-            logger.info("Certificate successfully revoked. Issuer DN: {}, Serial Number: {}", issuerDn, serialNumber);
+            logger.info("Certificate successfully revoked", kv("issuerDn", issuerDn), kv("serialNumber", serialNumber));
         } catch (final RestClientException e) {
             final var response = e.getResponse();
 
             if (e.getStatusCode() == HttpStatus.CONFLICT && response.contains("has previously been revoked")) {
-                logger.info("Certificate was already revoked in EJBCA. Issuer DN: {}, Serial Number: {}", issuerDn, serialNumber);
+                logger.info("Certificate was already revoked in EJBCA", kv("issuerDn", issuerDn), kv("serialNumber", serialNumber));
                 setRevokedStatus(certificateMetadata);
                 return;
             }

--- a/signer-cloud-server/src/main/java/com/wultra/signercloud/server/signer/SignerCleanupJob.java
+++ b/signer-cloud-server/src/main/java/com/wultra/signercloud/server/signer/SignerCleanupJob.java
@@ -24,6 +24,8 @@ import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * A scheduled job that performs cleanup operations on signers.
  *
@@ -42,9 +44,9 @@ class SignerCleanupJob {
     @SchedulerLock(name = "cleanupSigners")
     public void cleanupSigners() {
         final int limit = configurationProperties.getExpiration().job().limit();
-        logger.info("action: cleanupSigners, state: initiated, limit: {}", limit);
+        logger.info("Cleanup signers initiated", kv("action", "cleanupSigners"), kv("state", "initiated"), kv("limit", limit));
         LockAssert.assertLocked();
         final var result = signerService.cleanupSigners(limit);
-        logger.info("action: cleanupSigners, state: succeeded, count: {}", result);
+        logger.info("Cleanup signers succeeded", kv("action", "cleanupSigners"), kv("state", "succeeded"), kv("count", result));
     }
 }

--- a/signer-cloud-server/src/main/java/com/wultra/signercloud/server/signer/SignerController.java
+++ b/signer-cloud-server/src/main/java/com/wultra/signercloud/server/signer/SignerController.java
@@ -28,6 +28,8 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Controller for {@link Signer} operations.
  *
@@ -70,16 +72,16 @@ class SignerController {
     )
     @PostMapping
     void createUpdate(@Valid @RequestBody final CreateUpdateSignerRequest requestBody) {
-        logger.info("action: createUpdateSigner, state: initiated, userId: {}, externalSignerId: {}", requestBody.userId(), requestBody.externalSignerId());
+        logger.info("Create or update signer initiated", kv("action", "createUpdateSigner"), kv("state", "initiated"), kv("userId", requestBody.userId()), kv("externalSignerId", requestBody.externalSignerId()));
         final var result = Try.execute(
                 () -> signerService.createUpdateSigner(requestBody)
         );
 
         if (result.isSuccess()) {
-            logger.info("action: createUpdateSigner, state: succeeded");
+            logger.info("Create or update signer succeeded", kv("action", "createUpdateSigner"), kv("state", "succeeded"), kv("externalSignerId", requestBody.externalSignerId()));
         } else {
             final var error = result.getError();
-            logger.error("action: createUpdateSigner, state: failed, errorMessage: {}", error.getMessage());
+            logger.error("Create or update signer failed", kv("action", "createUpdateSigner"), kv("state", "failed"), kv("externalSignerId", requestBody.externalSignerId()), kv("errorMessage", error.getMessage()));
             throw error;
         }
     }
@@ -114,16 +116,16 @@ class SignerController {
             )
             @PathVariable final String externalSignerId,
             @Valid @RequestBody final UpdateSignerStatusRequest requestBody) {
-        logger.info("action: updateSignerStatus, state: initiated, externalSignerId: {}, newStatus: {}", externalSignerId, requestBody.signerStatus());
+        logger.info("Update signer status initiated", kv("action", "updateSignerStatus"), kv("state", "initiated"), kv("externalSignerId", externalSignerId), kv("newStatus", requestBody.signerStatus()));
         final var result =  Try.execute(
                 () -> signerService.updateStatus(externalSignerId, requestBody)
         );
 
         if (result.isSuccess()) {
-            logger.info("action: updateSignerStatus, state: succeeded");
+            logger.info("Update signer status succeeded", kv("action", "updateSignerStatus"), kv("state", "succeeded"), kv("externalSignerId", externalSignerId));
         } else {
             final var error = result.getError();
-            logger.error("action: updateSignerStatus, state: failed, errorMessage: {}", error.getMessage());
+            logger.error("Update signer status failed", kv("action", "updateSignerStatus"), kv("state", "failed"), kv("externalSignerId", externalSignerId), kv("errorMessage", error.getMessage()));
             throw error;
         }
     }
@@ -153,17 +155,17 @@ class SignerController {
             )
             @PathVariable final String externalSignerId
     ) {
-        logger.info("action: getSignerDetail, state: initiated, externalSignerId: {}", externalSignerId);
+        logger.info("Get signer detail initiated", kv("action", "getSignerDetail"), kv("state", "initiated"), kv("externalSignerId", externalSignerId));
         final var result = Try.execute(
                 () -> signerService.getDetail(externalSignerId)
         );
 
         if (result.isSuccess()) {
-            logger.info("action: getSignerDetail, state: succeeded");
+            logger.info("Get signer detail succeeded", kv("action", "getSignerDetail"), kv("state", "succeeded"), kv("externalSignerId", externalSignerId));
             return result.getResponse();
         } else {
             final var error = result.getError();
-            logger.info("action: getSignerDetail, state: failed, errorMessage: {}", error.getMessage());
+            logger.info("Get signer detail failed", kv("action", "getSignerDetail"), kv("state", "failed"), kv("externalSignerId", externalSignerId), kv("errorMessage", error.getMessage()));
             throw error;
         }
     }

--- a/signer-cloud-server/src/main/java/com/wultra/signercloud/server/signer/SignerRenewalJob.java
+++ b/signer-cloud-server/src/main/java/com/wultra/signercloud/server/signer/SignerRenewalJob.java
@@ -24,6 +24,8 @@ import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * A scheduled job that performs renewal operations on signers.
  *
@@ -42,9 +44,9 @@ class SignerRenewalJob {
     @SchedulerLock(name = "renewSigners")
     public void renewSigners() {
         final int limit = configurationProperties.getRenewal().job().limit();
-        logger.info("action: renewSigners, state: initiated, limit: {}", limit);
+        logger.info("Renew signers initiated", kv("action", "renewSigners"), kv("state", "initiated"), kv("limit", limit));
         LockAssert.assertLocked();
         final var result = signerService.renewSigners(limit);
-        logger.info("action: renewSigners, state: succeeded, count: {}", result);
+        logger.info("Renew signers succeeded", kv("action", "renewSigners"), kv("state", "succeeded"), kv("count", result));
     }
 }

--- a/signer-cloud-server/src/main/java/com/wultra/signercloud/server/signer/SignerService.java
+++ b/signer-cloud-server/src/main/java/com/wultra/signercloud/server/signer/SignerService.java
@@ -43,6 +43,8 @@ import java.time.Instant;
 import java.util.*;
 import java.util.regex.Pattern;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Service for {@link Signer} operations.
  *
@@ -94,7 +96,7 @@ class SignerService {
         signerRepository.markAsExpired(ids, Instant.now());
 
         if (callbackNotificationService.isCallbackEnabled(CallbackType.EXPIRED)) {
-            logger.info("Creating {} expiration callbacks.", signers.size());
+            logger.info("Creating expiration callbacks", kv("callbackCount", signers.size()), kv("callbackType", CallbackType.EXPIRED));
             for (final Signer signer : signers) {
                 notifyExpiredCallback(signer);
             }
@@ -153,7 +155,7 @@ class SignerService {
 
             saveIssuedCertificate(signer.getId(), x509Certificate);
         } catch (final CertificateEncodingException e) {
-            logger.warn("Exception when encoding certificate to base64 during renewal, externalSignerId: {}", signer.getExternalSignerId());
+            logger.warn("Exception when encoding certificate to base64 during renewal", kv("externalSignerId", signer.getExternalSignerId()));
             throw new CertificateProcessingException("Certificate could not be encoded during renewal", e);
         }
 
@@ -181,7 +183,7 @@ class SignerService {
         try {
             return objectMapper.writeValueAsString(payload);
         } catch (JacksonException e) {
-            logger.warn("Unable to serialize {} to JSON.", payload, e);
+            logger.warn("Unable to serialize callback payload to JSON", kv("payload", payload), e);
             return "{}";
         }
     }
@@ -367,7 +369,7 @@ class SignerService {
         final var certificatesToRevokeCount = certificatesMetadata.size();
 
         for (var i = 0; i < certificatesToRevokeCount; i++) {
-            logger.info("Revoking certificate {}/{} in EJBCA", i + 1, certificatesToRevokeCount);
+            logger.info("Revoking certificate in EJBCA", kv("certificateIndex", i + 1), kv("certificateCount", certificatesToRevokeCount));
             final var certificateMetadata = certificatesMetadata.get(i);
             certificateRevocationService.revokeCertificate(certificateMetadata, revocationReason);
         }


### PR DESCRIPTION
🤖
## Description

Improves log quality in `signer-cloud-server` by adopting structured-logging best practices from epic wultra/tasklist#864.

- **L6 — `StructuredArguments.kv()`**: contextual IDs (`externalSignerId`, `documentId`, `userId`, `documentUuid`, `serialNumber`, `issuerDn`, `callbackType`, `callbackEventId`, `registrationId`, …) are now logged as queryable top-level JSON fields instead of `{}` string interpolation.
- **L7 — action/state pattern**: `action` and `state` are emitted as separate `kv()` arguments, always with a short, human-readable message as the first argument. The pre-existing `logger.info("action: X, state: Y, id: {}", …)` interpolation in the controllers (the exact anti-pattern this issue targets) has been converted, and `initiated → succeeded/failed` lifecycle logging is applied consistently across controllers and jobs.

### Notes
- No empty-message logs (avoids the `null` `message` field in Elasticsearch).
- Trailing throwables are preserved so stack traces are still logged.
- Only IDs are logged — no secrets or document content.
- Logging-only change; no behavioural/functional change. `logstash-logback-encoder` was already a dependency.

## Testing

- `mvn -pl signer-cloud-server -am test` — compiles cleanly, all existing tests pass.

## Closes

Closes #220
