### PR TITLE
docs #231: consolidate changelog and add copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,64 @@
+# Copilot Instructions — signer-cloud
+
+This file captures conventions used when working with GitHub Copilot in the
+`signer-cloud` repository.
+
+---
+
+## Changelog
+
+All notable changes are recorded in the root [`CHANGELOG.md`](../CHANGELOG.md), which
+**strictly** follows the [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/)
+format and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### Format
+
+- The file starts with the canonical header referencing both
+  [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
+  [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+- A `## [Unreleased]` section sits at the top; new entries are always added there.
+- Change-type subsections, in this order, using **only** those that apply:
+  `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`.
+- Versions are linkable via reference-style links at the bottom of the file.
+
+### Entries
+
+- Each entry is human-readable (not a raw commit message) and starts with a verb.
+- Each entry **links to the issue, not the PR**, using the form:
+  ```markdown
+  - Fixed NPE when the signer list is empty [(#231)](https://github.com/wultra/signer-cloud/issues/231)
+  ```
+- Issue URLs use `https://github.com/wultra/signer-cloud/issues/N`.
+- Add an entry for every user-visible change. Skip only changes with no user-visible
+  impact (e.g. pure CI/tooling).
+
+### Releasing
+
+On release:
+
+1. Rename `## [Unreleased]` to `## [x.y.z] - YYYY-MM-DD` (ISO 8601 date).
+2. Add a fresh, empty `## [Unreleased]` section above it.
+3. Update the `[unreleased]` reference link to compare from the new version to `HEAD`.
+4. Add the new version's compare reference link.
+
+### Example
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- New feature description [(#N)](https://github.com/wultra/signer-cloud/issues/N)
+
+## [1.0.0] - 2025-03-01
+### Changed
+- Changed behaviour description [(#N)](https://github.com/wultra/signer-cloud/issues/N)
+
+[unreleased]: https://github.com/wultra/signer-cloud/compare/1.0.0...HEAD
+[1.0.0]: https://github.com/wultra/signer-cloud/compare/0.10.0...1.0.0
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
 
-## 1.0.0 (TBA)
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
+## [Unreleased]
 ### Changed
+- Improved structured logging quality in the service layer: contextual IDs are now logged as queryable `StructuredArguments.kv()` fields and log calls use the action/state pattern with meaningful messages [(#220)](https://github.com/wultra/signer-cloud/issues/220)
+- Upgraded Docker base image to `ibm-semeru-runtimes:open-jdk-25.0.3.0-jre-noble` (OpenJDK 25) [(#226)](https://github.com/wultra/signer-cloud/issues/226)
+- Migrated to Spring Boot 4 and Jackson 3 [(#225)](https://github.com/wultra/signer-cloud/issues/225)
 
-- Upgraded Docker base image to `ibm-semeru-runtimes:open-jdk-25.0.3.0-jre-noble` (OpenJDK 25) [(226)](https://github.com/wultra/signer-cloud/issues/226)
-- Migrated to Spring Boot 4 and Jackson 3 [(225)](https://github.com/wultra/signer-cloud/issues/225)
+[unreleased]: https://github.com/wultra/signer-cloud/compare/0.10.0...HEAD


### PR DESCRIPTION
🤖
## Description

Brings `signer-cloud` in line with the Wultra changelog and Copilot conventions defined in the parent epic wultra/tasklist#986.

- **`CHANGELOG.md`** rewritten to **strictly** follow [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/): canonical header (Keep a Changelog + Semantic Versioning), a `## [Unreleased]` section at the top, `### Changed` entries with corrected `[(#N)]` issue links, and a reference-style `[unreleased]` compare link.
- **`.github/copilot-instructions.md`** added, documenting the changelog conventions (format, entry rules, release procedure) with `signer-cloud`-specific repo name and issue URLs.

### Notes

- Incorporates the #220 structured-logging changelog entry from PR #238 so the entry is preserved regardless of merge order.
- ⚠️ **Merge coordination with #238:** both PRs touch `CHANGELOG.md`. If this PR merges first, #238 will conflict on `CHANGELOG.md` and should simply drop its changelog hunk (the #220 entry is already present here). If #238 merges first, this branch rebases cleanly (entry already present).
- Historical released sections (0.9.x / 0.10.0) were intentionally not reconstructed, per the DoD minimum.

## Closes

Closes #231
